### PR TITLE
Make CMake module path relative

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # FIND LOCAL NCURSES
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/Modules/")
 set(CURSES_NEED_NCURSE TRUE)
 find_package(Ncursesw REQUIRED)
 add_library(NCurses INTERFACE IMPORTED)


### PR DESCRIPTION
Using CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR means other projects that add_subdirectory directly on the library will work.

Otherwise everything should be the same.

