### PR TITLE
Force the ncurses include path when using brew

### DIFF
--- a/cmake/Modules/FindNcursesw.cmake
+++ b/cmake/Modules/FindNcursesw.cmake
@@ -122,6 +122,9 @@ if(CURSES_USE_NCURSESW)
 
   if(${OSX_BREW_NCURSES})
     set(CURSES_INCLUDE_PATH /usr/local/opt/ncurses/include)
+    if (APPLE)
+      add_definitions(-D_XOPEN_SOURCE_EXTENDED)
+    endif()
   else()
     find_path(CURSES_INCLUDE_PATH
       NAMES ncursesw/ncurses.h ncursesw/curses.h ncurses.h curses.h

--- a/cmake/Modules/FindNcursesw.cmake
+++ b/cmake/Modules/FindNcursesw.cmake
@@ -120,10 +120,14 @@ if(CURSES_USE_NCURSESW)
   get_filename_component(_cursesLibDir "${CURSES_NCURSESW_LIBRARY}" PATH)
   get_filename_component(_cursesParentDir "${_cursesLibDir}" PATH)
 
-  find_path(CURSES_INCLUDE_PATH
-    NAMES ncursesw/ncurses.h ncursesw/curses.h ncurses.h curses.h
-    HINTS "${_cursesParentDir}/include"
+  if(${OSX_BREW_NCURSES})
+    set(CURSES_INCLUDE_PATH /usr/local/opt/ncurses/include)
+  else()
+    find_path(CURSES_INCLUDE_PATH
+      NAMES ncursesw/ncurses.h ncursesw/curses.h ncurses.h curses.h
+      HINTS "${_cursesParentDir}/include"
     )
+  endif()
 
   # Previous versions of FindCurses provided these values.
   if(NOT DEFINED CURSES_LIBRARY)


### PR DESCRIPTION
Adding this line seems to make sure that the right headers are included, and the right library is linked, and yet I cannot get wide character support to work.

The `add_wchstr` macro is still not defined.

What platform is wide character support know to work on? I'm trying to get a working build of it to try and make some comparisons. I've searched high and low for how the includes are still mixed up.

Opening this PR to see a little collaborative inspiration can help figure this out