### PR TITLE
Guard to avoid initialization fail.

### DIFF
--- a/include/cppurses/system/system.hpp
+++ b/include/cppurses/system/system.hpp
@@ -40,7 +40,8 @@ class System {
 
     /// Create a Widget_t object, set it as head widget and call System::run().
     /** \p args... are passed on to the Widget_t constructor. Blocks until
-     *  System::exit() is called, returns the exit code. */
+     *  System::exit() is called, returns the exit code. Will throw a
+     *  std::runtime_error if screen cannot be initialized. */
     template <typename Widget_t, typename... Args>
     int run(Args&&... args) {
         Widget_t head_widget(std::forward<Args>(args)...);
@@ -49,10 +50,12 @@ class System {
     }
 
     /// Set \p head as head widget and call System::run().
+    /** Will throw a std::runtime_error if screen cannot be initialized. */
     int run(Widget& head);
 
     /// Launch the main Event_loop and start processing Events.
-    /** Blocks until System::exit() is called, returns the exit code. */
+    /** Blocks until System::exit() is called, returns the exit code. Will throw
+     *  a std::runtime_error if screen cannot be initialized. */
     int run();
 
     /// Immediately send the event filters and then to the intended receiver.

--- a/src/terminal/terminal.cpp
+++ b/src/terminal/terminal.cpp
@@ -61,7 +61,16 @@ void Terminal::initialize() {
     this->setup_resize_signal_handler();
     std::setlocale(LC_ALL, "en_US.UTF-8");
 
-    ::initscr();
+    //::initscr(); // would print error message and call exit() on fail                      
+    // newterm() is equivalent to ::initscr(), but returns NULL on fail 
+    if (::newterm(::getenv("TERM"), stdout, stdin) == NULL) {
+	    if (::newterm("xterm-256color", stdout, stdin) == NULL) {
+		    // TODO: HANDLE UNABLE TO INITIALIZE SCR ERROR HERE !!!
+		    fprintf(stderr, "Error: Could not initialize screen\n");
+		    exit(EXIT_FAILURE);
+	    }
+    }
+
     is_initialized_ = true;
     ::noecho();
     ::keypad(::stdscr, true);

--- a/src/terminal/terminal.cpp
+++ b/src/terminal/terminal.cpp
@@ -3,7 +3,9 @@
 #include <clocale>
 #include <csignal>
 #include <cstddef>
+#include <cstdio>
 #include <cstdlib>
+#include <stdexcept>
 
 #include <ncurses.h>
 #include <signal.h>
@@ -61,14 +63,10 @@ void Terminal::initialize() {
     this->setup_resize_signal_handler();
     std::setlocale(LC_ALL, "en_US.UTF-8");
 
-    //::initscr(); // would print error message and call exit() on fail                      
-    // newterm() is equivalent to ::initscr(), but returns NULL on fail 
-    if (::newterm(::getenv("TERM"), stdout, stdin) == NULL) {
-	    if (::newterm("xterm-256color", stdout, stdin) == NULL) {
-		    // TODO: HANDLE UNABLE TO INITIALIZE SCR ERROR HERE !!!
-		    fprintf(stderr, "Error: Could not initialize screen\n");
-		    exit(EXIT_FAILURE);
-	    }
+    if (::newterm(std::getenv("TERM"), stdout, stdin) == nullptr) {
+        if (::newterm("xterm-256color", stdout, stdin) == nullptr) {
+            throw std::runtime_error{"Unable to initialize screen."};
+        }
     }
 
     is_initialized_ = true;


### PR DESCRIPTION
Next example resulted in error:
```bash
TERM="foo"  # Change $TERM to foo
./demo # executing cppurses demo
# Instead of executing (error prints -> from ncurses::initscr())
Error opening terminal: foo.   # With exit code (1)
```
**Pointing that there is maybe a problem, it might be solved some other (better) way.**
Tried to fix it with this patch:

```
1) If could initialize with $TERM -> okay
2) if not then -> Try to initialize with xterm-256color
3) if both failed then -> Handle error (TODO)
```
This solution prevents potentially undesired exit(), but on the other hand, hint that there is a problem with $TERM (shown at exit) might be useful for the end user.

*Compiled library and tested with demos (everything looks fine).*