### PR TITLE
std::quick_exit() was overlooked in Apple's libc++ implementation.

### DIFF
--- a/src/terminal/terminal.cpp
+++ b/src/terminal/terminal.cpp
@@ -20,7 +20,11 @@
 
 extern "C" void handle_sigint(int /* sig*/) {
     cppurses::System::terminal.uninitialize();
-    std::quick_exit(0);
+#if !defined __APPLE__
+  std::quick_exit(0);
+#else
+  std::exit(0);
+#endif
 }
 
 namespace {


### PR DESCRIPTION
Don't use quick exit on Apple systems because Cupertino forgot to include it in libc++