### PR TITLE
Add Textbox support for Key::Backspace_2

### DIFF
--- a/include/cppurses/system/events/key.hpp
+++ b/include/cppurses/system/events/key.hpp
@@ -186,7 +186,7 @@ struct Key {
         Arrow_left,
         Arrow_right,
         Home,
-        Backspace_2,  // unused? int 263
+        Backspace_2, // numpad backspace and backspace on some laptops
 
         // Function keys, up to 63.
         // Add fn number to enum for more. ex) F15 key = Key::Function + 15;

--- a/src/widget/textbox.cpp
+++ b/src/widget/textbox.cpp
@@ -42,7 +42,8 @@ bool Textbox::key_press_event(const Key::State& keyboard) {
         return true;
     }
     switch (keyboard.key) {
-        case Key::Backspace: {
+        case Key::Backspace: 
+        case Key::Backspace_2: {
             auto cursor_index = this->cursor_index();
             if (cursor_index == 0) {
                 break;


### PR DESCRIPTION
I'm not sure why, but the keyboard on my ThinkPad running Debian Linux is indeed sending 262 (Backspace_2) events when I press the backspace key. Thus, I am not able to delete anything in cppurses::Textboxes.

This adds support for Key::Backspace_2 in addition to Key::Backspace in Textbox. It doesn't appear this key is referenced anywhere else in the project.