### PR TITLE
Implement fallback to exit() when MinGW is being used

### DIFF
--- a/src/terminal/terminal.cpp
+++ b/src/terminal/terminal.cpp
@@ -21,7 +21,7 @@
 extern "C" void handle_sigint(int /* sig*/)
 {
     cppurses::System::terminal.uninitialize();
-#if !defined __APPLE__
+#if !defined __APPLE__ && !defined __MINGW32__
     std::quick_exit(0);
 #else
     std::exit(0);


### PR DESCRIPTION
MinGW does not have a complete libc implementation and fails to recognize quick_exit(). Just like with Apple in #25, exit() should be used instead if MinGW is detected.